### PR TITLE
fixed error for integer streams

### DIFF
--- a/R/DSC_MOA.R
+++ b/R/DSC_MOA.R
@@ -92,8 +92,9 @@ update.DSC_MOA <- function(object, dsd, n, verbose=FALSE, ...) {
 #     }
 
     d <- get_points(dsd, n)
+    d <- apply(d, c(1,2), as.numeric)
     .jcall("StreamMOA", "V", "update", object$javaObj,
-      .jarray(as.matrix(d), dispatch = TRUE))
+      .jarray(d, dispatch = TRUE))
    }
 
 


### PR DESCRIPTION
Hey,

streamMOA currently doesn't seem to handle integer streams well. It took me a while to track this down but it easily happens when reading from a file. As an example, the following example will cause an error:

```R
library(streamMOA)

## works
# data = data.frame(a=c(1,2), b=c(3, 4))
## does not work
data = data.frame(a=c(1L,2L), b=c(3L, 4L))

stream = DSD_Memory(data)
algorithm=DSC_ClusTree()
update(algorithm, stream, 2)
```
Presumably, rJava cannot find a method signature for the integer array (as indicated by the "[I" in the error message):

> Error in .jcall("StreamMOA", "V", "update", object$javaObj, .jarray(as.matrix(d),  :
   method update with signature (Lmoa/clusterers/AbstractClusterer;[[I)V not found

I think the easiest solution is to just cast the data to a numeric matrix on the R side with a simple apply. Since the apply function already returns a matrix, we can also get rid of the specific cast to a matrix. As an alternative I tried to use `.jarray`'s `contents.class` parameter with `"[D"` but that doesn't seem to work.


